### PR TITLE
Add custom class on panes with splitpanes-class

### DIFF
--- a/src/components/splitpanes.vue
+++ b/src/components/splitpanes.vue
@@ -361,7 +361,8 @@ export default {
           const {
             'splitpanes-min': min = 0,
             'splitpanes-max': max = 100,
-            'splitpanes-size': Default = this.defaultWidth
+            'splitpanes-size': Default = this.defaultWidth,
+            'splitpanes-class': customClass = ""
           } = attrs
 
           const savedWidth = this.panes[i] && this.panes[i].savedWidth !== undefined ? this.panes[i].savedWidth : null
@@ -371,7 +372,8 @@ export default {
             width: savedWidth !== null ? savedWidth : parseFloat(Default),
             index: i,
             min: parseFloat(min),
-            max: parseFloat(max)
+            max: parseFloat(max),
+            customClass: customClass
           })
 
           if (i) this.$set(this.splitters, i - 1, { id: `splitter-${i - 1}`, index: i - 1 })
@@ -402,7 +404,7 @@ export default {
           attrs: {
             id: `pane_${i}`
           },
-          class: 'splitpanes__pane',
+          class: 'splitpanes__pane' + ' ' + this.panes[i].customClass,
           style: {
             ...(this.horizontal ? { height: `${this.panes[i].width}%` } : null),
             ...(!this.horizontal ? { width: `${this.panes[i].width}%` } : null)


### PR DESCRIPTION
Hi @antoniandre is it possible to implement a custom class props on panes like this ?

This custom class is very usefull in case your default css for .splitpanes__pane is set to overflow: hidden and you want to overide it for specific panes.
The overflow props need to be on the panes element and  setting it on the inner element don't work (for overflow css props I mean)

Exmple usage with this modification :

```
<template>
  <splitpanes horizontal>
    <scrolable-component splitpanes-class="overflow-auto" />
    <onother-component />
  </splitpanes>
</template>

<style scoped>
.overflow-auto {
  overflow: auto !important;
}
</style>
```

The component become now scrollable.

PS: I didn't test it on the src but only on dist. It was working fine for me.

Regards