### PR TITLE
Workaround for circular references

### DIFF
--- a/src/components/splitpanes.vue
+++ b/src/components/splitpanes.vue
@@ -341,10 +341,24 @@ export default {
           'container', 'Ctor', 'context', 'parent', 'componentInstance', 'componentOptions',
           'fnContext', 'fnOptions']
 
-        const slotsExport = JSON.stringify(this.$slots.default, (name, val) => {
-          // Discard the properties listed in array to prevent circular reference.
-          return discardProps.indexOf(name) > -1 ? undefined : val
-        })
+	  
+        const getCircularReplacer = () => {
+          const seen = new WeakSet();
+          return (key, value) => {
+            if(discardProps.indexOf(key) > -1) {
+              return;
+            }
+            if (typeof value === "object" && value !== null) {
+              if (seen.has(value)) {
+                return;
+              }
+              seen.add(value);
+            }
+            return value;
+          };
+        };
+	  
+        const slotsExport = JSON.stringify(this.$slots.default, getCircularReplacer());
 
         slotsHaveChanged = this.slotsCopy !== slotsExport
 


### PR DESCRIPTION
Because your library is the most usable with this resize function, but useless without "watch-slots", I searched a workaround for the circular reference situation.

I combined the [recommendation from MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value#Examples) with your discardProps Solution, which works in our case.

Because we currently started with Vue.JS it's not fully clear for me, why JSON.stringify is necessary to transfer changes to nested components, because this looks like a performance bottleneck.

But because we will invest some more time into our Vue.JS project, I probably can provide a better solution for this. 
Let me know, when you see some problems with the workaround.
