### PR TITLE
Add vue3 emits option

### DIFF
--- a/src/components/splitpanes/splitpanes.vue
+++ b/src/components/splitpanes/splitpanes.vue
@@ -3,6 +3,8 @@ import { h } from 'vue'
 
 export default {
   name: 'splitpanes',
+  emits: ['ready','resize','resized','pane-click','pane-maximize','pane-add','pane-remove','splitter-click'],
+  
   props: {
     horizontal: { type: Boolean },
     pushOtherPanes: { type: Boolean, default: true },


### PR DESCRIPTION
Hi and thanks for the great library!

In Vue3 there are warnings because of the event emits:
[Vue warn]: Component emitted event "resized" but it is neither declared in the emits option nor as an "onResized" prop.

In vue3 it is recommended to include a emits option: [Vue3 Docs](https://v3.vuejs.org/guide/migration/emits-option.html#overview)

I hope you can use this. Maybe recheck the event names