### PR TITLE
Add `preventPointerEvents` API

### DIFF
--- a/src/components/splitpanes/splitpanes.vue
+++ b/src/components/splitpanes/splitpanes.vue
@@ -10,7 +10,8 @@ export default {
     pushOtherPanes: { type: Boolean, default: true },
     dblClickSplitter: { type: Boolean, default: true },
     rtl: { type: Boolean, default: false }, // Right to left direction.
-    firstSplitter: { type: Boolean }
+    firstSplitter: { type: Boolean },
+    preventPointerEvents: { type: Boolean }
   },
 
   provide () {
@@ -84,6 +85,8 @@ export default {
       this.bindEvents()
       this.touch.mouseDown = true
       this.touch.activeSplitter = splitterIndex
+
+      if (this.preventPointerEvents) this.handlePointerEventsClass('add')
     },
 
     onMouseMove (event) {
@@ -107,6 +110,16 @@ export default {
         this.touch.dragging = false
         this.unbindEvents()
       }, 100)
+
+      if (this.preventPointerEvents) this.handlePointerEventsClass('remove')
+    },
+
+    handlePointerEventsClass (action) {
+      const els = document.querySelectorAll('.splitpanes object, .splitpanes iframe')
+      Array.prototype.forEach.call(els, (i) => {
+        if (action === 'add') i.classList.add('prevent-pointer-events')
+        if (action === 'remove') i.classList.remove('prevent-pointer-events')
+      })
     },
 
     // If touch device, detect double tap manually (2 taps separated by less than 500ms).
@@ -730,6 +743,10 @@ export default {
   &__splitter {touch-action: none;}
   &--vertical > .splitpanes__splitter {min-width: 1px;cursor: col-resize;}
   &--horizontal > .splitpanes__splitter {min-height: 1px;cursor: row-resize;}
+
+  .prevent-pointer-events {
+    pointer-events: none!important;
+  }
 }
 .splitpanes.default-theme {
   .splitpanes__pane {

--- a/src/views/documentation.vue
+++ b/src/views/documentation.vue
@@ -813,6 +813,10 @@
       code first-splitter
       span.code.ml2 Default: false
       p Displays the first splitter when set to true. This allows maximizing the first pane on splitter double click.
+    li
+      code prevent-pointer-events
+      span.code.ml2 Default: false
+      p Set the pointer-events attribute of the object element and iframe element to none when set to true.
 
   h2.mt12.pt12.mb2
     a(href="#release-notes") Release Notes


### PR DESCRIPTION
Resizing will fail when there is an object element or iframe element inside the component, because the element hijacks mouse events and the document‘s mouse events will not work.
```html
<splitpanes style="height: 400px">
  <pane>
    <object type="application/pdf"
      data="/test.pdf"
      width="100%"
      height="100%">
    </object>
  </pane>
  <pane>5</pane>
</splitpanes>
```
Enabling the `preventPointerEvents` attribute can add `pointer-events: none;` style to object element and iframe element to prevent this.