### PR TITLE
Emit splitter double click event

### DIFF
--- a/src/components/splitpanes/splitpanes.vue
+++ b/src/components/splitpanes/splitpanes.vue
@@ -4,7 +4,7 @@ import { h } from 'vue'
 export default {
   // eslint-disable-next-line vue/multi-word-component-names
   name: 'splitpanes',
-  emits: ['ready', 'resize', 'resized', 'pane-click', 'pane-maximize', 'pane-add', 'pane-remove', 'splitter-click'],
+  emits: ['ready', 'resize', 'resized', 'pane-click', 'pane-maximize', 'pane-add', 'pane-remove', 'splitter-click', 'splitter-dbl-click'],
 
   props: {
     horizontal: { type: Boolean },
@@ -145,6 +145,7 @@ export default {
         return pane
       })
       this.panes[splitterIndex].size -= totalMinSizes
+      this.$emit('splitter-dbl-click', this.panes[splitterIndex])
       this.$emit('pane-maximize', this.panes[splitterIndex])
       this.$emit('resized', this.panes.map(pane => ({ min: pane.min, max: pane.max, size: pane.size })))
     },
@@ -342,6 +343,8 @@ export default {
 
       if (this.dblClickSplitter) {
         elm.ondblclick = event => this.onSplitterDblClick(event, splitterIndex + 1)
+      } else {
+        elm.ondblclick = () => this.$emit('splitter-dbl-click', this.panes[splitterIndex + 1])
       }
 
       nextPaneNode.parentNode.insertBefore(elm, nextPaneNode)
@@ -667,7 +670,7 @@ export default {
     dblClickSplitter (enable) {
       const splitters = [...this.container.querySelectorAll('.splitpanes__splitter')]
       splitters.forEach((splitter, i) => {
-        splitter.ondblclick = enable ? event => this.onSplitterDblClick(event, i) : undefined
+        splitter.ondblclick = enable ? event => this.onSplitterDblClick(event, i) : this.$emit('splitter-dbl-click', this.panes[i])
       })
     }
   },

--- a/src/views/documentation.vue
+++ b/src/views/documentation.vue
@@ -622,6 +622,9 @@
     li.
       #[code.mr2 splitter-click] returns the next pane object (with its dimensions) directly after the clicked splitter.#[br]
       This event is only emitted if dragging did not occur between mousedown and mouseup.
+    li.
+      #[code.mr2 splitter-dbl-click] returns the next pane object (with its dimensions) directly after the double clicked splitter.#[br]
+      This event is only emitted if dragging did not occur between mousedown and mouseup.
   p.mt4 Try resizing panes and check the logs bellow.
 
   splitpanes.default-theme.example(
@@ -631,6 +634,7 @@
     @pane-click="log('pane-click', $event)"
     @ready="log('ready', $event)"
     @splitter-click="log('splitter-click', $event)"
+    @splitter-dbl-click="log('splitter-dbl-click', $event)"
     style="height: 400px")
     pane(v-for="i in 3" :key="i" :min-size="10")
       span {{ i }}
@@ -653,6 +657,7 @@
       @pane-click="log('pane-click', $event)"
       @ready="log('ready', $event)"
       @splitter-click="log('splitter-click', $event)"
+      @splitter-dbl-click="log('splitter-dbl-click', $event)"
       style="height: 400px"&gt;
       &lt;pane v-for="i in 3" :key="i" min-size="10"&gt;
         &lt;span&gt;{{ '\{\{ i \}\}' }}&lt;/span&gt;


### PR DESCRIPTION
This PR implements what suggested in #182 by emitting a  `splitter-dbl-click` event when double-clicking on the splitter. The payload of the event will be the same as that of `splitter-click`, i.e. the pane following the splitter.

Closes #182 #181