### PR TITLE
Feature: Add `revert` Prop to Reverse Pane Order

### DIFF
--- a/src/components/splitpanes/splitpanes.vue
+++ b/src/components/splitpanes/splitpanes.vue
@@ -10,6 +10,7 @@ export default {
     horizontal: { type: Boolean },
     pushOtherPanes: { type: Boolean, default: true },
     dblClickSplitter: { type: Boolean, default: true },
+    revert: { type: Boolean, default: false },
     rtl: { type: Boolean, default: false }, // Right to left direction.
     firstSplitter: { type: Boolean }
   },
@@ -686,6 +687,11 @@ export default {
   },
 
   render () {
+    let children = this.$slots.default()
+    if (this.revert) {
+      // Reverse the order of panes: [1, 2, 3] becomes [3, 2, 1]
+      children = children.slice().reverse()
+    }
     return h(
       'div',
       {
@@ -694,11 +700,12 @@ export default {
           'splitpanes',
           `splitpanes--${this.horizontal ? 'horizontal' : 'vertical'}`,
           {
-            'splitpanes--dragging': this.touch.dragging
+            'splitpanes--dragging': this.touch.dragging,
+            'splitpanes--reverse': this.revert
           }
         ]
       },
-      this.$slots.default()
+      children
     )
   }
 }

--- a/src/components/splitpanes/splitpanes.vue
+++ b/src/components/splitpanes/splitpanes.vue
@@ -689,7 +689,6 @@ export default {
   render () {
     let children = this.$slots.default()
     if (this.revert) {
-      // Reverse the order of panes: [1, 2, 3] becomes [3, 2, 1]
       children = children.slice().reverse()
     }
     return h(

--- a/src/views/isolated-test-view.vue
+++ b/src/views/isolated-test-view.vue
@@ -2,8 +2,9 @@
 //- This is an isolated test view. Just for testing purpose.
 div
   w-button.mr2(@click="toggleHorizontal") Horizontal
-  w-button(@click="hidePane2 = !hidePane2") toggle pane 2
-  splitpanes.default-theme(:horizontal="horizontal" style="height: 400px")
+  w-button.mr2(@click="hidePane2 = !hidePane2") toggle pane 2
+  w-button(@click="revertOrder = !revertOrder") revert order
+  splitpanes.default-theme(:horizontal="horizontal" style="height: 400px" :revert="revertOrder")
     pane(size="85") 1
     pane(size="5" v-if="!hidePane2") 2
     pane(size="10") 3
@@ -15,6 +16,7 @@ import { Splitpanes, Pane } from '@/components/splitpanes/index'
 
 const horizontal = ref(true)
 const hidePane2 = ref(false)
+const revertOrder = ref(false)
 const panesNumber = 3
 
 const togglePane2 = () => {


### PR DESCRIPTION
This pull request introduces a new `revert` prop to the splitpanes component. When enabled, the component reverses the order of its panes (e.g., from `[1, 2, 3]` to `[3, 2, 1]`), providing developers with an easy way to alter the layout without needing to restructure the markup manually.

## Background
Previous attempts to invert the pane order using only CSS proved insufficient because the pane resize calculations were not inverted accordingly. This discrepancy led to incorrect behavior during resize operations, as detailed in issues #216 and #148.

## Key Changes
- **Props :** Add an optional prop `revert`, defaulting to `false`.
- **Render Function:** Modified the render function to check for the `revert` prop. When true, it reverses the order of the slot children.
- **CSS Class:** Added the `splitpanes--reverse` CSS class to indicate the reversed state, which can be used for additional styling if necessary.

These changes are opt-in and maintain backward compatibility. Please review the modifications and merge if they meet the project requirements.

Fix #216
Fix #148