### PR TITLE
equalizeAfterAddOrRemove addedPane extra check

### DIFF
--- a/src/components/splitpanes/splitpanes.vue
+++ b/src/components/splitpanes/splitpanes.vue
@@ -498,7 +498,7 @@ const equalizeAfterAddOrRemove = ({ addedPane, removedPane } = {}) => {
 
   for (const pane of panes.value) {
     const addedPaneHasGivenSize = addedPane?.givenSize !== null && addedPane?.id === pane.id
-    if (!addedPaneHasGivenSize) pane.size = Math.max(Math.min(equalSpace, pane.max), pane.min)
+    if (addedPane && !addedPaneHasGivenSize) pane.size = Math.max(Math.min(equalSpace, pane.max), pane.min)
 
     leftToAllocate -= pane.size
     if (pane.size >= pane.max) ungrowable.push(pane.id)


### PR DESCRIPTION
I faced an issue with .size when fired onPaneRemove and onPaneAdd simultaneously by some reasons. This fixed problem for me because fixed code isn't affecting .size when onPaneRemove fired when changes aren't required